### PR TITLE
Fix Arc shape protocol conformance and Sendable issues

### DIFF
--- a/iOS-26-by-Examples/Views/AnimatableView.swift
+++ b/iOS-26-by-Examples/Views/AnimatableView.swift
@@ -32,19 +32,28 @@ struct AnimatableView: View {
     }
 }
 
-@Animatable
 struct Arc: Shape {
     var startAngle: Angle
     var endAngle: Angle
-    @AnimatableIgnored var clockwise: Bool
+    var clockwise: Bool
+
+    var animatableData: AnimatablePair<Angle.AnimatableData, Angle.AnimatableData> {
+        get { AnimatablePair(startAngle.animatableData, endAngle.animatableData) }
+        set {
+            startAngle.animatableData = newValue.first
+            endAngle.animatableData = newValue.second
+        }
+    }
 
     func path(in rect: CGRect) -> Path {
-        Path {
-            $0.addArc(center: CGPoint(x: rect.midX, y: rect.midY),
-                      radius: rect.width / 2,
-                      startAngle: startAngle,
-                      endAngle: endAngle,
-                      clockwise: clockwise)
+        Path { path in
+            path.addArc(
+                center: CGPoint(x: rect.midX, y: rect.midY),
+                radius: rect.width / 2,
+                startAngle: startAngle,
+                endAngle: endAngle,
+                clockwise: clockwise
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- 修复了 Arc shape 在 iOS 18 SDK 中的编译错误
- 解决了 Shape 协议一致性问题
- 修复了 Sendable 类型参数的编译错误

## Changes
- 移除了 `@Animatable` 宏的使用
- 手动实现 `animatableData` 属性来支持动画
- 将 `animatableData` 直接集成到 Arc struct 中，避免了扩展引起的 Sendable 问题
- 保持了原有的动画功能

## Test Plan
- [x] 编译通过，无错误
- [x] 动画功能正常工作
- [x] 点击 "Animate" 按钮可以看到圆弧平滑动画